### PR TITLE
Add scripts for MQ cross-region replication lab

### DIFF
--- a/build_mq_crr.sh
+++ b/build_mq_crr.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Script Name : build_mq_crr.sh
+# Description : Provision an IBM MQ Native-HA cross-region replication lab.
+#               Creates a three-node primary region and a three-node replica
+#               region using the icr.io/ibm-messaging/mq:latest image and
+#               configures asynchronous CRR between them.
+# =============================================================================
+
+set -euo pipefail
+
+IMAGE="icr.io/ibm-messaging/mq:latest"
+COMPOSE_FILE="docker-compose-crr.yml"
+QMGR_NAME="QMHA"
+DATA_DIR="./data"
+
+# ANSI colors
+RED="\033[0;31m"; GREEN="\033[0;32m"; CYAN="\033[0;36m"; NC="\033[0m"
+info(){ echo -e "${CYAN}$*${NC}"; }
+ok(){ echo -e "${GREEN}$*${NC}"; }
+die(){ echo -e "${RED}$*${NC}"; exit 1; }
+
+needs_bin() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required tool: $1"
+}
+
+needs_bin docker
+
+# --------- Create data directories ---------
+info "Creating data directories..."
+for d in qmha-a qmha-b qmha-c qmha-dr-a qmha-dr-b qmha-dr-c; do
+  mkdir -p "${DATA_DIR}/${d}"
+done
+ok "Data directories ready."
+
+# --------- Generate docker-compose file ---------
+info "Generating ${COMPOSE_FILE}..."
+cat > "$COMPOSE_FILE" <<'COMPOSE'
+version: '3.8'
+services:
+  qmha-a:
+    image: icr.io/ibm-messaging/mq:latest
+    hostname: qmha-a
+    container_name: qmha-a
+    environment:
+      - LICENSE=accept
+      - MQ_NATIVE_HA=true
+      - MQ_QMGR_NAME=QMHA
+      - MQ_DR_ROLE=PRIMARY
+      - MQ_DR_REPLICA_HOSTS=qmha-dr-a:1500,qmha-dr-b:1500,qmha-dr-c:1500
+    volumes:
+      - ./data/qmha-a:/mnt/mqm
+    ports:
+      - "1414:1414"
+  qmha-b:
+    image: icr.io/ibm-messaging/mq:latest
+    hostname: qmha-b
+    container_name: qmha-b
+    environment:
+      - LICENSE=accept
+      - MQ_NATIVE_HA=true
+      - MQ_QMGR_NAME=QMHA
+      - MQ_DR_ROLE=PRIMARY
+      - MQ_DR_REPLICA_HOSTS=qmha-dr-a:1500,qmha-dr-b:1500,qmha-dr-c:1500
+    volumes:
+      - ./data/qmha-b:/mnt/mqm
+  qmha-c:
+    image: icr.io/ibm-messaging/mq:latest
+    hostname: qmha-c
+    container_name: qmha-c
+    environment:
+      - LICENSE=accept
+      - MQ_NATIVE_HA=true
+      - MQ_QMGR_NAME=QMHA
+      - MQ_DR_ROLE=PRIMARY
+      - MQ_DR_REPLICA_HOSTS=qmha-dr-a:1500,qmha-dr-b:1500,qmha-dr-c:1500
+    volumes:
+      - ./data/qmha-c:/mnt/mqm
+  qmha-dr-a:
+    image: icr.io/ibm-messaging/mq:latest
+    hostname: qmha-dr-a
+    container_name: qmha-dr-a
+    environment:
+      - LICENSE=accept
+      - MQ_NATIVE_HA=true
+      - MQ_QMGR_NAME=QMHA
+      - MQ_DR_ROLE=REPLICA
+    volumes:
+      - ./data/qmha-dr-a:/mnt/mqm
+    ports:
+      - "1514:1414"
+  qmha-dr-b:
+    image: icr.io/ibm-messaging/mq:latest
+    hostname: qmha-dr-b
+    container_name: qmha-dr-b
+    environment:
+      - LICENSE=accept
+      - MQ_NATIVE_HA=true
+      - MQ_QMGR_NAME=QMHA
+      - MQ_DR_ROLE=REPLICA
+    volumes:
+      - ./data/qmha-dr-b:/mnt/mqm
+  qmha-dr-c:
+    image: icr.io/ibm-messaging/mq:latest
+    hostname: qmha-dr-c
+    container_name: qmha-dr-c
+    environment:
+      - LICENSE=accept
+      - MQ_NATIVE_HA=true
+      - MQ_QMGR_NAME=QMHA
+      - MQ_DR_ROLE=REPLICA
+    volumes:
+      - ./data/qmha-dr-c:/mnt/mqm
+COMPOSE
+ok "${COMPOSE_FILE} generated."
+
+# --------- Start containers ---------
+info "Starting CRR environment..."
+docker compose -f "$COMPOSE_FILE" up -d
+ok "Containers started."
+
+# --------- Configure cross-region replication ---------
+info "Configuring cross-region replication..."
+docker exec qmha-a bash -lc "mqcli crtmqha --dr-replica qmha-dr-a:1500 qmha-dr-b:1500 qmha-dr-c:1500" && \
+  ok "Cross-region replication configured." || \
+  die "Failed to configure cross-region replication."
+
+info "Build complete. Primary listener exposed on port 1414, replica on 1514."

--- a/destroy_mq_crr.sh
+++ b/destroy_mq_crr.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Script Name : destroy_mq_crr.sh
+# Description : Tear down the IBM MQ CRR lab environment and clean data.
+# =============================================================================
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose-crr.yml"
+DATA_DIR="./data"
+
+if [[ -f "$COMPOSE_FILE" ]]; then
+  docker compose -f "$COMPOSE_FILE" down
+fi
+
+rm -f "$COMPOSE_FILE"
+
+# Remove only CRR data directories
+for d in qmha-a qmha-b qmha-c qmha-dr-a qmha-dr-b qmha-dr-c; do
+  rm -rf "${DATA_DIR}/${d}"
+done
+
+# Remove data dir if empty
+rmdir "$DATA_DIR" 2>/dev/null || true
+
+echo "CRR environment destroyed."

--- a/verify_crr.sh
+++ b/verify_crr.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Script Name : verify_crr.sh
+# Description : Basic verification for the IBM MQ CRR lab. Ensures containers
+#               are running, queue managers are RUNNING, and displays
+#               cross-region replication status.
+# =============================================================================
+
+set -euo pipefail
+
+QMGR_NAME="${QMGR_NAME:-QMHA}"
+SERVICES=(qmha-a qmha-b qmha-c qmha-dr-a qmha-dr-b qmha-dr-c)
+
+RED="\033[0;31m"; GREEN="\033[0;32m"; CYAN="\033[0;36m"; NC="\033[0m"
+die(){ echo -e "${RED}❌ $*${NC}"; exit 1; }
+ok(){ echo -e "${GREEN}✅ $*${NC}"; }
+info(){ echo -e "${CYAN}ℹ️  $*${NC}"; }
+
+command -v docker >/dev/null 2>&1 || die "docker not found"
+
+for s in "${SERVICES[@]}"; do
+  info "Checking container ${s}..."
+  docker ps --format '{{.Names}}' | grep -qx "$s" || die "Container $s not running"
+  docker exec "$s" bash -lc "dspmq -m ${QMGR_NAME} -o status" | grep -q 'RUNNING' || die "Queue manager in $s not RUNNING"
+  ok "$s is RUNNING"
+done
+
+info "Retrieving replication status from primary..."
+docker exec qmha-a bash -lc "mqcli rdqmstatus -m ${QMGR_NAME}" || die "mqcli rdqmstatus failed"
+
+ok "CRR verification completed."


### PR DESCRIPTION
## Summary
- add build script to provision MQ Native-HA cross-region replication using icr.io/ibm-messaging/mq:latest
- add destroy script to tear down CRR lab
- add verify script to check container and replication status

## Testing
- `bash -n build_mq_crr.sh destroy_mq_crr.sh verify_crr.sh`
- `command -v shellcheck >/dev/null 2>&1 && shellcheck build_mq_crr.sh destroy_mq_crr.sh verify_crr.sh || echo "shellcheck not installed"`

------
https://chatgpt.com/codex/tasks/task_e_68af2e567f48832e9b32edfb0bfd2ee7